### PR TITLE
Create multiple HTTP streams intentionally.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1361,6 +1361,7 @@ name = "ripunzip"
 version = "0.2.2"
 dependencies = [
  "anyhow",
+ "arbitrary",
  "clap 4.0.29",
  "criterion",
  "env_logger",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,6 +31,7 @@ reqwest = { version = "0.11.13", features = ["blocking"] }
 tempfile = "3.3.0"
 thiserror = "1.0.37"
 zip = "0.6.3"
+arbitrary = { version = "1.2.0", features = [ "derive" ] }
 
 [dev-dependencies]
 hexdump = "0.1.1"

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -1198,6 +1198,7 @@ name = "ripunzip"
 version = "0.2.2"
 dependencies = [
  "anyhow",
+ "arbitrary",
  "clap",
  "env_logger",
  "indicatif",

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,3 +12,4 @@ pub use unzip::NullProgressReporter;
 pub use unzip::UnzipEngine;
 pub use unzip::UnzipOptions;
 pub use unzip::UnzipProgressReporter;
+pub use unzip::UnzipUriOptions;


### PR DESCRIPTION
This change will allow the unzip-from-URI option to intentionally create multiple HTTP streams to support several parallel readers, subject to parameters passed in that can limit this behavior.

This doesn't appear to make things quicker with the server I'm trying right now. It seems like we are probably limited by total network bandwidth rather than some artificial server-side limit.