### PR TITLE
positioned_io draft to prevent expensive Arc<Mutex<File>>

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1269,6 +1269,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "767eb9f07d4a5ebcb39bbf2d452058a93c011373abf6832e24194a1c3f004794"
 
 [[package]]
+name = "positioned-io"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09b9485cf7f528baf34edd811ec8283a168864912e11d0b7d3e0510738761114"
+dependencies = [
+ "byteorder",
+ "libc",
+ "winapi",
+]
+
+[[package]]
 name = "ppv-lite86"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1447,6 +1458,7 @@ dependencies = [
  "itertools 0.10.5",
  "log",
  "monitor",
+ "positioned-io",
  "progress-streams",
  "rayon",
  "reqwest",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,7 @@ indicatif = "0.17.2"
 itertools = "0.10.5"
 log = "0.4.17"
 monitor = "0.1.0"
+positioned-io = "0.3.1"
 progress-streams = "1.1.0"
 rayon = "1.6.0"
 reqwest = { version = "0.11.13", features = ["blocking"] }


### PR DESCRIPTION
Hi, I've noticed you're using Arc<Mutex<File>>, which seems like a bottleneck for heavy parallellization. However a preliminary bench didn't yield as much improvement as I'd hoped, however could be due to the fact that those aren't utilizing threads as aggressively.

Anyway here is the code. Note that this is completely unrefined, I was using `Box::leak` to get it to compile. I don't have a real use case for this other than I was playing around a bit, so if you have no interest in this, that's fine for me.

For a quick summary, you can read the positioned_io description. Basically it allows parallel reads on a `&File` (note the missing mut) without changing the file pos. It's also used by `rc-zip`, which allows extracting in parallel. however it is mainly unmaintained and the underlying library seems to have [UB](https://github.com/sozu-proxy/circular/issues/9), but investigating into this direction might be worth it.