### PR TITLE
Fix bug where cache cells not being discarded.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1312,6 +1312,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "ranges"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f781d391cd4838df77e09fd26e33a87e0ac9bf2edf6ff770cfc65f83d50e3948"
+
+[[package]]
 name = "rayon"
 version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1430,6 +1436,7 @@ dependencies = [
  "log",
  "monitor",
  "progress-streams",
+ "ranges",
  "rayon",
  "regex",
  "reqwest",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,7 @@ itertools = "0.10.5"
 log = "0.4.17"
 monitor = "0.1.0"
 progress-streams = "1.1.0"
+ranges = "0.3.3"
 rayon = "1.6.0"
 regex = "1.10.2"
 reqwest = { version = "0.11.13", features = ["blocking"] }


### PR DESCRIPTION
In patterns of access where we read the same bytes more than once, we may have discarded cache cells too early, which might have resulted in the need to issue extra https requests and thus slowdowns.
