### PR TITLE
Fix typo in --help output

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -56,7 +56,7 @@ enum Commands {
         uri_args: UriArgs,
     },
 
-    /// Unzips a zip file from a URO
+    /// Unzips a zip file from a URI
     UnzipUri {
         #[command(flatten)]
         uri_args: UriArgs,


### PR DESCRIPTION
It says

```
Commands:
  list-file   Lists a zip file
  unzip-file  Unzip a zip file
  list-uri    Lists a zip file from a URI
  unzip-uri   Unzips a zip file from a URO
  help        Print this message or the help of the given subcommand(s)
```

URO seems like a typo