### PR TITLE
Build .deb on Ubuntu 22.02

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,7 +60,7 @@ jobs:
 
   deb:
     name: BuildDeb
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     env:
       CARGO_TERM_COLOR: always
     steps:


### PR DESCRIPTION
As needed by Chromium at the moment.