### PR TITLE
[dep]: update ranges to 0.4.0 as ranges 0.3.4 was yanked.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,7 @@ itertools = "0.10.5"
 log = "0.4.17"
 monitor = "0.1.0"
 progress-streams = "1.1.0"
-ranges = "0.3.3"
+ranges = "0.4.0"
 rayon = "1.6.0"
 regex = "1.10.2"
 reqwest = { version = "0.11.13", features = ["blocking"] }


### PR DESCRIPTION
Fixes error in `cargo install ripinzup`
```
Caused by:
  failed to select a version for the requirement `ranges = "^0.3.3"`
  candidate versions found which didn't match: 0.4.0
  location searched: crates.io index
  required by package `ripunzip v1.2.2`
  perhaps a crate was updated and forgotten to be re-vendored?
```