### PR TITLE
Fix small TODO; `checked_add`

### DIFF
--- a/src/unzip/cloneable_seekable_reader.rs
+++ b/src/unzip/cloneable_seekable_reader.rs
@@ -50,8 +50,13 @@ impl<R: Read + Seek> Inner<R> {
         }
         let read_result = self.r.read(buf);
         if let Ok(bytes_read) = read_result {
-            // TODO, once stabilised, use checked_add_signed
-            self.pos += bytes_read as u64;
+            self.pos = self
+                .pos
+                .checked_add(bytes_read as u64)
+                .ok_or(std::io::Error::new(
+                    std::io::ErrorKind::InvalidInput,
+                    "Read too far forward",
+                ))?;
         }
         read_result
     }


### PR DESCRIPTION
The original TODO mentioned `checked_add_signed`, but the valued added (`bytes_read`) is a `usize` so I assume that was a typo.

No README changes are required for this change.

- [x] Tests pass
- [x] Appropriate changes to README are included in PR