### PR TITLE
Create create_release.yml

### DIFF
--- a/.github/workflows/create_release.yml
+++ b/.github/workflows/create_release.yml
@@ -1,0 +1,38 @@
+name: Create Github Release Files
+
+permissions:
+  contents: write
+
+on:
+  release:
+    types: [created]
+
+jobs:
+  publish-rust:
+    name: Publish for ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest, ubuntu-24.04-arm, windows-11-arm]
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Set up Rust Toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Publish CLI Binary
+        uses: taiki-e/upload-rust-binary-action@v1
+        with:
+          locked: true
+          # (required) Comma-separated list of binary names (non-extension portion of filename) to build and upload.# Note that glob pattern is not supported yet.
+          bin: ripunzip
+          # (optional) On which platform to distribute the .tar.gz file.# [default value: unix]# [possible values: all, unix, windows, none]
+          tar: unix
+          zip: windows
+          archive: $bin-$tag-$target
+          token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Fixes #56 

- [x] Tests pass
- [ ] Appropriate changes to README are included in PR

Hi. This PR adds a simple workflow to automate github releases:
- you make a new release with a new tag.
- workflow creates binaries automatically and adds to release.

I haven't updated README yet, because I wanted to clarify few things beforehand:

- You're currently only providing a `deb` package. Is it strictly required or would a universal linux executable be acceptable?
- What targets do you wantto support? I added all available github runners, with latest os versions.