### PR TITLE
Update ci workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,32 +41,36 @@ jobs:
       RUSTFLAGS: --cfg deny_warnings -Dwarnings
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
         with:
           submodules: recursive
       - uses: dtolnay/rust-toolchain@master
         with:
           toolchain: ${{matrix.rust}}
           components: rustfmt
-      # The `{ sharedKey: ... }` allows different actions to share the cache.
-      - uses: Swatinem/rust-cache@v1
-        with: { sharedKey: fullBuild }
+      - name: Set up Rust Cache
+        uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: ripunzip
+          cache-targets: true
+          cache-all-crates: true
       - name: Install dependencies on Linux
         if: matrix.os == ''
         run: sudo apt-get install libssl-dev pkg-config
-      - run: cargo test --workspace ${{steps.testsuite.outputs.exclude}}
+      - run: cargo test --locked --workspace ${{steps.testsuite.outputs.exclude}}
 
   deb:
-    name: BuildDeb
+    name: Build Deb
     runs-on: ubuntu-22.04
     env:
       CARGO_TERM_COLOR: always
     steps:
-      - uses: actions/checkout@v2
-      - uses: hecrj/setup-rust-action@v1
-      - run: cargo install cargo-deb # sadly not supported by dtolnay/install
-      - name: BuildDeb
-        run: cargo deb
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: cargo-bins/cargo-binstall@main
+      - run: cargo binstall cargo-deb --no-confirm # sadly not supported by dtolnay/install
+      - name: Build Deb
+        run: cargo deb -- --locked
       - name: Upload Deb Artifact
         uses: actions/upload-artifact@v4
         with:
@@ -80,11 +84,15 @@ jobs:
     env:
       CARGO_TERM_COLOR: always
     steps:
-      - uses: actions/checkout@v2
-      - uses: hecrj/setup-rust-action@v1
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - name: Set up Rust Cache
+        uses: Swatinem/rust-cache@v2
         with:
-          components: clippy
-      - uses: Swatinem/rust-cache@v1
+          shared-key: ripunzip
+          cache-targets: true
+          cache-all-crates: true
+
       - run: cargo clippy --workspace --tests -- -Dclippy::all
 
   # Mention outdated dependencies
@@ -94,10 +102,9 @@ jobs:
     env:
       CARGO_TERM_COLOR: always
     steps:
-      - uses: actions/checkout@v2
-      - uses: dtolnay/install@master
-        with:
-          crate: cargo-outdated
+      - uses: actions/checkout@v4
+      - uses: dtolnay/install@cargo-outdated
+
       - run: cargo outdated -R -w
 
   # Check rustfmt is good
@@ -105,10 +112,9 @@ jobs:
     name: Format
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: hecrj/setup-rust-action@v1
-        with:
-          components: rustfmt
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+
       - run: cargo fmt --all -- --check
 
   # Detect cases where documentation links don't resolve and such.
@@ -116,10 +122,15 @@ jobs:
     name: Docs
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: hecrj/setup-rust-action@v1
-      - uses: Swatinem/rust-cache@v1
-        with: { sharedKey: fullBuild }
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - name: Set up Rust Cache
+        uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: ripunzip
+          cache-targets: true
+          cache-all-crates: true
+
       - run: |
           for package in $(cargo metadata --no-deps --format-version=1 | jq -r '.packages[] | .name'); do
             cargo rustdoc --color always -p "$package" -- -D warnings


### PR DESCRIPTION
- [x] Tests pass

Hi. This PR updates the current [ci.yml](https://github.com/google/ripunzip/blob/7c8eac44c4d2fe27ee677906fe7e0057c1cbba1d/.github/workflows/ci.yml):

- `actions/checkout@v2` -> `actions/checkout@v4`.
- `Swatinem/rust-cache@v1` -> `Swatinem/rust-cache@v2`. Caches will appear again and greatly speedup the ci.
- `hecrj/setup-rust-action@v1` -> `dtolnay/rust-toolchain@stable`.
- `cargo install cargo-deb` command -> `cargo-bins/cargo-binstall@main`. Speeds up `cargo-deb` setup.

Ci runs reduced from 3:30-4:30 to 1:40-2:10.


