### PR TITLE
feat: aliases for subcommands

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -36,12 +36,14 @@ struct RipunzipArgs {
 #[derive(Subcommand, Debug)]
 enum Commands {
     /// Lists a zip file
+    #[clap(visible_alias = "lf")]
     ListFile {
         #[command(flatten)]
         file_args: FileArgs,
     },
 
     /// Unzip a zip file
+    #[clap(visible_alias = "uf")]
     UnzipFile {
         #[command(flatten)]
         file_args: FileArgs,
@@ -51,12 +53,14 @@ enum Commands {
     },
 
     /// Lists a zip file from a URI
+    #[clap(visible_alias = "lu")]
     ListUri {
         #[command(flatten)]
         uri_args: UriArgs,
     },
 
     /// Unzips a zip file from a URI
+    #[clap(visible_alias = "uu")]
     UnzipUri {
         #[command(flatten)]
         uri_args: UriArgs,


### PR DESCRIPTION
I'm using this, I quite like it. thanks for making this! 

I propose to add aliases for the 4 subcommands, since they're quite long to type. Descriptive names are nice, but when you need to type it a lot it's more comfortable to have short names as an option. 

I like to alias `ripunzip` to `rz`.
So instead of `ripunzip unzip-file` I can just type `rz uf`

Help menu looks like this:

```
A tool to unzip an archive in parallel

Usage: ripunzip [OPTIONS] <COMMAND>

Commands:
  list-file   Lists a zip file [aliases: lf]
  unzip-file  Unzip a zip file [aliases: uf]
  list-uri    Lists a zip file from a URI [aliases: lu]
  unzip-uri   Unzips a zip file from a URI [aliases: uu]
  help        Print this message or the help of the given subcommand(s)

Options:
  -v, --verbose...  Increase logging verbosity
  -q, --quiet...    Decrease logging verbosity
  -h, --help        Print help (see more with '--help')
  -V, --version     Print version
```

If you'd like the alias to be hidden, that's also possible

- [x] Tests pass
- [x] Appropriate changes to README are included in PR