### PR TITLE
feat: Allow configuring the number of decompression threads

### DIFF
--- a/fuzz/fuzz_targets/fuzz_ripunzip.rs
+++ b/fuzz/fuzz_targets/fuzz_ripunzip.rs
@@ -87,6 +87,7 @@ fuzz_target!(|input: Inputs| {
         filename_filter: None,
         progress_reporter: Box::new(progress_reporter),
         password: None,
+        thread_pool: None,
     };
     let zipfile = tempdir.path().join("file.zip");
     let mut zip_data = Vec::new();


### PR DESCRIPTION
This change introduces a new `--threads` command-line option to allow users to manually specify the number of threads used for decompression. This is particularly useful in scenarios with high disk I/O latency but high bandwidth, where fine-tuning the thread count can improve performance.

To maintain backward compatibility, the existing `--single-threaded` flag is preserved and is made mutually exclusive with the new `--threads` option.

- Added `--threads` argument to `UnzipArgs` in `src/main.rs`.
- Used `clap`'s `conflicts_with` attribute to ensure `--single-threaded` and `--threads` cannot be used together.
- Initialized Rayon's global thread pool with the specified number of threads.
- Updated the logic to treat `--threads 1` as equivalent to `--single-threaded`.

- [x] Tests pass
- [x] Appropriate changes to README are included in PR