### PR TITLE
Fix clippy warning about unnecessary Default

### DIFF
--- a/src/unzip/seekable_http_reader.rs
+++ b/src/unzip/seekable_http_reader.rs
@@ -42,8 +42,10 @@ const DEFAULT_SKIP_AHEAD_THRESHOLD: u64 = 2 * 1024 * 1024; // 2MB
 
 /// A hint to the [`SeekableHttpReaderEngine`] about the expected access pattern.
 #[derive(Debug, Clone, Copy, Eq, PartialEq)]
+#[derive(Default)]
 pub(crate) enum AccessPattern {
     /// We expect accesses all over the file.
+    #[default]
     RandomAccess,
     /// We expect accesses starting from the beginning and moving to the end,
     /// though there might be some jumping around if multiple threads are
@@ -51,11 +53,6 @@ pub(crate) enum AccessPattern {
     SequentialIsh,
 }
 
-impl Default for AccessPattern {
-    fn default() -> Self {
-        Self::RandomAccess
-    }
-}
 
 /// Errors that may be returned by a [`SeekableHttpReaderEngine` or `SeekableHttpReader`].
 #[derive(Error, Debug)]


### PR DESCRIPTION
Fixes #120

```
error: this `impl` can be derived
  --> src/unzip/seekable_http_reader.rs:54:1
   |
54 | / impl Default for AccessPattern {
55 | |     fn default() -> Self {
56 | |         Self::RandomAccess
57 | |     }
58 | | }
   | |_^
   |
   = help: for further information visit https://rust-lang.github.io/rust-clippy/rust-1.91.0/index.html#derivable_impls
   = note: `-D clippy::derivable-impls` implied by `-D clippy::all`
   = help: to override `-D clippy::all` add `#[allow(clippy::derivable_impls)]`
help: replace the manual implementation with a derive attribute and mark the default variant
   |
45 + #[derive(Default)]
46 ~ pub(crate) enum AccessPattern {
47 |     /// We expect accesses all over the file.
48 ~     #[default]
49 ~     RandomAccess,
   |
```