### PR TITLE
Use cargo-deny for dependency linting

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -136,3 +136,16 @@ jobs:
             cargo rustdoc --color always -p "$package" -- -D warnings
           done
         env: { RUSTDOCFLAGS: -Dwarnings }
+
+  # Lint dependencies with cargo-deny
+  deny:
+    name: Deny
+    runs-on: ubuntu-latest
+    env:
+      CARGO_TERM_COLOR: always
+    steps:
+      - uses: actions/checkout@v4
+      - uses: cargo-bins/cargo-binstall@main
+      - run: cargo binstall cargo-deny --no-confirm # not supported by dtolnay/install
+
+      - run: cargo deny check

--- a/README.md
+++ b/README.md
@@ -39,6 +39,8 @@ There's also `cargo fuzz` support for comparitive fuzzing against non-parallel u
 to try to spot any unforeseen circumstances where we do anything differently. If you
 change the core unzipping logic please use this.
 
+`cargo-deny` is used to keep dependencies secure and license-compatible. If you change the project's dependencies at all be sure to run `cargo deny check` on your codebase.
+
 #### License and usage notes
 
 This is not an officially supported Google product.

--- a/deny.toml
+++ b/deny.toml
@@ -1,0 +1,67 @@
+[graph]
+targets = [
+]
+all-features = false
+no-default-features = false
+
+[output]
+feature-depth = 1
+
+[advisories]
+ignore = [
+    "RUSTSEC-2024-0375", # unmaintained: atty@0.2.14
+    "RUSTSEC-2025-0119", # unmaintained: number_prefix@0.4.0
+    "RUSTSEC-2025-0134", # unmaintained: rustls-pemfile@1.0.4
+    "RUSTSEC-2021-0127", # unmaintained: serde_cbor@0.11.2
+]
+
+[licenses]
+# List of explicitly allowed licenses
+# See https://spdx.org/licenses/ for list of possible licenses
+# [possible values: any SPDX 3.11 short identifier (+ optional exception)].
+allow = [
+    "MIT",
+    "Apache-2.0",
+    "Apache-2.0 WITH LLVM-exception",
+    "Unicode-3.0",
+    "BSD-3-Clause",
+    "Zlib",
+]
+confidence-threshold = 0.8
+exceptions = [
+    # Each entry is the crate and version constraint, and its specific allow
+    # list
+    #{ allow = ["Zlib"], crate = "adler32" },
+]
+
+[licenses.private]
+ignore = false
+registries = [
+]
+
+[bans]
+multiple-versions = "warn"
+wildcards = "allow"
+highlight = "all"
+workspace-default-features = "allow"
+external-default-features = "allow"
+allow = [
+]
+allow-workspace = false
+deny = [
+]
+skip = [
+]
+skip-tree = [
+]
+
+[sources]
+unknown-registry = "warn"
+unknown-git = "warn"
+allow-registry = ["https://github.com/rust-lang/crates.io-index"]
+allow-git = []
+
+[sources.allow-org]
+github = []
+gitlab = []
+bitbucket = []


### PR DESCRIPTION
This would prevent issues like #127 from cropping up in the future by using `cargo-deny` to lint dependencies for license conflicts and security advisories.

Considerations before merging:
- Currently a number of unmaintained packages down the dependency graph are added to `cargo-deny`'s 'ignore' list as they would otherwise be counted as blocking security advisories.
- Gating the CI pipeline on security advisories may be problematic; it could begin to fail suddenly if a new security advisory is added to the registry.
- `cargo-deny` also flags up a few duplicate dependencies. Should this be considered important?

- [x] Tests pass
- [X] Appropriate changes to README are included in PR